### PR TITLE
Test import fix

### DIFF
--- a/ui_automation_tests/selenium-base-image/Dockerfile
+++ b/ui_automation_tests/selenium-base-image/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7-stretch
 
 RUN apt-get update && apt-get install -yq \
+    firefox-esr \
     chromium=70.0.3538.110-1~deb9u1 \
     git-core=1:2.11.0-3+deb9u4 \
     xvfb=2:1.19.2-1+deb9u5 \

--- a/ui_automation_tests/selenium-base-image/Dockerfile
+++ b/ui_automation_tests/selenium-base-image/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -yq \
     git-core=1:2.11.0-3+deb9u4 \
     xvfb=2:1.19.2-1+deb9u5 \
     xsel=1.2.0-2+b1 \
-    unzip=6.0-21+deb9u1 \
+    unzip \
     python-pytest=3.0.6-1 \
     libgconf2-4=3.2.6-4+b1 \
     libncurses5=6.0+20161126-1+deb9u2 \

--- a/ui_automation_tests/selenium-base-image/Dockerfile
+++ b/ui_automation_tests/selenium-base-image/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.7-stretch
 
 RUN apt-get update && apt-get install -yq \
-    firefox-esr \
     chromium=70.0.3538.110-1~deb9u1 \
     git-core=1:2.11.0-3+deb9u4 \
     xvfb=2:1.19.2-1+deb9u5 \


### PR DESCRIPTION
 Getting any error importing a package on apt -install on the e2e tests which is causing all the e2e tests not to run. See below the console
https://jenkins.ci.uktrade.io/view/LITE/job/lite-e2e-internal-frontend/265/console

Just removing the version of the package so it installs the latest each time.