### PR TITLE
Adding support for LOCAL_LITE_API_URL environment variable.

### DIFF
--- a/ui_automation_tests/conftest.py
+++ b/ui_automation_tests/conftest.py
@@ -37,7 +37,19 @@ def pytest_addoption(parser):
 
     if env.lower() == 'local':
         parser.addoption("--internal_url", action="store", default="http://localhost:" + str(os.environ.get('PORT')), help="url")
-        parser.addoption("--lite_api_url", action="store", default=str(os.environ.get('LITE_API_URL')), help="url")
+
+        # Get LITE API URL.
+        lite_api_url = os.environ.get(
+            "LOCAL_LITE_API_URL",
+            os.environ.get("LITE_API_URL"),
+        )
+        parser.addoption(
+            "--lite_api_url",
+            action="store",
+            default=lite_api_url,
+            help="url",
+        )
+
     elif env == 'demo':
         raise NotImplementedError('This is the demo environment - Try another environment instead')
     else:


### PR DESCRIPTION
If you're running end-to-end tests from your local machine but the frontend and API are running in Docker containers, the LITE API URL will need to be configured twice—once for the frontend, and once for the end-to-end tests.

`LITE_API_URL` is the URL for the API as visible from the frontend. `LOCAL_LITE_API_URL` is the URL for the API as visible locally. If `LOCAL_LITE_API_URL` isn't set, `LITE_API_URL` will be used instead (i.e. current behaviour).