### PR TITLE
Update Jenkinsfile

### DIFF
--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -84,6 +84,7 @@ parameters
             } catch (error) {
                     archiveArtifacts artifacts: "ui_automation_tests/allure-results/**.*"
                     error.message
+		    currentBuild.result = "UNSTABLE"
                   }
 
             }
@@ -123,7 +124,6 @@ try
   catch (error)
   {
     error.message
-    currentBuild.result = "UNSTABLE"
   }
 }
 

--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -123,6 +123,7 @@ try
   catch (error)
   {
     error.message
+    currentBuild.result = "UNSTABLE"
   }
 }
 


### PR DESCRIPTION
Currently if the tests error for example there is a syntax error, the tests pass which isn't ideal. This sets the build to UNSTABLE if there is a syntax error

