### PR TITLE
Update Jenkinsfile

### DIFF
--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -123,6 +123,7 @@ try
   catch (error)
   {
     error.message
+    currentBuild.result = "UNSTABLE"
   }
 }
 


### PR DESCRIPTION
Currently if the tests error for example there is a syntax error, the tests pass which isn't ideal. This sets the build to UNSTABLE if there is a syntax error

