### PR TITLE
test: Less slack spam

### DIFF
--- a/pipeline/Jenkinsfile
+++ b/pipeline/Jenkinsfile
@@ -99,12 +99,13 @@ parameters
       script {
        //unarchive mapping: ['ui_automation_tests/allure-results/**.*': '.']
        generateAllureReport()
-       // Send Slack notification
-       sendSlackNotification()
       }
     }
+    changed {
+           // Send Slack notification
+       sendSlackNotification()
+    }
   }
-
 }
 
 // Generate Allure report function
@@ -153,7 +154,7 @@ def sendSlackNotification()
 		}
 
 		// Set slack channel
-		channel = "lite-development-team"
+		channel = "lite-merging"
 
 		// Send notifications
 		slackSend (color: colourCode, message: message, channel: "#${channel}")


### PR DESCRIPTION
Change the Slack Notifications to go to lite-merging channel
Change the Slack Notifications to only send when there has been a change in result for a build for example previous build was a success, next build is a success - don't notify, if previous build was a success, next build is a failure - notify.
